### PR TITLE
Reactive Filters/Timeline

### DIFF
--- a/src/frontend/components/DataARC.vue
+++ b/src/frontend/components/DataARC.vue
@@ -25,6 +25,8 @@
     <timeline-section
       id="temporal-section"
       v-model="temporalFilters"
+      :filters="compiledFilters"
+      :triggers="filterCount"
     />
     <map-section
       id="spatial-section"

--- a/src/frontend/components/TimelineContainer.vue
+++ b/src/frontend/components/TimelineContainer.vue
@@ -27,7 +27,7 @@
       </b-row>
       <b-row>
         <b-col ref="timelineContainer" class="mt-3 mb-3 text-center">
-          <timeline :width="timelineWidth" v-model="currentSelectedRange" />
+          <timeline :triggers="triggers" :filters="filters" :width="timelineWidth" v-model="currentSelectedRange" />
         </b-col>
       </b-row>
       <b-row>
@@ -137,6 +137,16 @@ export default {
   name: 'TimelineContainer',
   components: {
     Timeline,
+  },
+  props: {
+    filters: {
+      type: [Object, Boolean],
+      default: false,
+    },
+    triggers: {
+      type: [Number, Boolean],
+      default: false,
+    },
   },
   data() {
     return {

--- a/src/frontend/components/timeline-components/Timeline.vue
+++ b/src/frontend/components/timeline-components/Timeline.vue
@@ -227,7 +227,7 @@ export default {
         period = 'decades'
       }
       this.$emit('input', {
-        start: rangeData.startDate,
+        begin: rangeData.startDate,
         end: rangeData.startDate + this.ranges[period] * multiplier
       })
     },

--- a/src/frontend/components/timeline-components/Timeline.vue
+++ b/src/frontend/components/timeline-components/Timeline.vue
@@ -41,9 +41,6 @@ import * as d3api from 'd3';
 import * as d3Selection from 'd3-selection';
 
 import TimelineSvg from './TimelineSvg.vue';
-// const d3 = {
-//   ...d3api, ...d3Selection,
-// }
 
 const category_colors = ['#6177aa', '#fc8d62', '#66c2a5', '#54278f', '#a63603'];
 
@@ -192,25 +189,7 @@ export default {
         this.reloadTimelineData()
       },
       deep: true,
-    }
-    // filters: {
-    //   handler(newValue, oldValue) {
-    //     if ('temporal' in newValue && 'temporal' in oldValue) {
-    //       const a = newValue.temporal
-    //       const b = oldValue.temporal
-    //       if (a === b) return true
-    //       if (a == null || b == null) return false
-    //       if (a.length !== b.length) return false
-    //       for (let i = 0; i < a.length; ++i) {
-    //         if (a[i] !== b[i]) return false
-    //       }
-    //     }
-    //     console.log("Filters changed")
-    //     console.log({newValue, oldValue})
-    //     this.reloadTimelineData()
-    //   },
-    //   deep: true,
-    // }
+    },
   },
   mounted() {
     this.getTimelineDataByPeriod(this.initialPeriod, this.initialStartDate);
@@ -301,14 +280,6 @@ export default {
 </script>
 
 <style>
-/* #timeline {
-  display: inline-block;
-  position: relative;
-  width: 100%;
-  vertical-align: top;
-  overflow: hidden;
-} */
-
 #timeline .label {
   height: 50px;
   transition: opacity 0.5s linear;


### PR DESCRIPTION
Filters on the map, keywords, and timeline are not reactive to each other in this PR

- add triggers property to timeline - may need to be renamed
- use featureCount property from DataARC.vue to monitor added filters in timeline
- re-query all timeliine sections with updated filter object and reset the activeTimeline 
- if timeline query result is empty and there was an active view of child timelines (centuries, decades) then create an empty return with 0 values for that timeperiod

