### PR TITLE
Cytoscape - Implement fcose extension to improve initial graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "compass-mixins": "^0.12.10",
     "core-js": "^3.1.2",
     "cytoscape-cola": "^2.4.0",
+    "cytoscape-fcose": "^1.2.3",
     "d3": "^6.2.0",
     "graphql": "^15.3.0",
     "js-cookie": "^2.2.1",

--- a/src/frontend/components/concept-components/Cytoscape.vue
+++ b/src/frontend/components/concept-components/Cytoscape.vue
@@ -95,6 +95,7 @@
 
 <script>
 import cola from 'cytoscape-cola'
+import fcose from 'cytoscape-fcose'
 
 export default {
   name: 'Network',
@@ -115,6 +116,73 @@ export default {
   },
   data() {
     return {
+      fcoseSettings: {
+        name: 'fcose',
+        // 'draft', 'default' or 'proof'
+        // - "draft" only applies spectral layout
+        // - "default" improves the quality with incremental layout (fast cooling rate)
+        // - "proof" improves the quality with incremental layout (slow cooling rate)
+        quality: 'default',
+        // Use random node positions at beginning of layout
+        // if this is set to false, then quality option must be "proof"
+        randomize: true,
+        // Whether or not to animate the layout
+        animate: true,
+        // Duration of animation in ms, if enabled
+        animationDuration: 1000,
+        // Easing of animation, if enabled
+        animationEasing: undefined,
+        // Fit the viewport to the repositioned nodes
+        fit: true,
+        // Padding around layout
+        padding: 30,
+        // Whether to include labels in node dimensions. Valid in "proof" quality
+        nodeDimensionsIncludeLabels: false,
+        // Whether or not simple nodes (non-compound nodes) are of uniform dimensions
+        uniformNodeDimensions: false,
+        // Whether to pack disconnected components - valid only if randomize: true
+        packComponents: true,
+
+        /* spectral layout options */
+
+        // False for random, true for greedy sampling
+        samplingType: true,
+        // Sample size to construct distance matrix
+        sampleSize: 45,
+        // Separation amount between nodes
+        nodeSeparation: 75,
+        // Power iteration tolerance
+        piTol: 0.0000002,
+
+        /* incremental layout options */
+
+        // Node repulsion (non overlapping) multiplier
+        nodeRepulsion: 7000,
+        // Ideal edge (non nested) length
+        idealEdgeLength: 300,
+        // Divisor to compute edge forces
+        edgeElasticity: 0.45,
+        // Nesting factor (multiplier) to compute ideal edge length for nested edges
+        nestingFactor: 0.1,
+        // Maximum number of iterations to perform
+        numIter: 2500,
+        // For enabling tiling
+        tile: true,
+        // Represents the amount of the vertical space to put between the zero degree members during the tiling operation(can also be a function)
+        tilingPaddingVertical: 10,
+        // Represents the amount of the horizontal space to put between the zero degree members during the tiling operation(can also be a function)
+        tilingPaddingHorizontal: 10,
+        // Gravity force (constant)
+        gravity: 0.35,
+        // Gravity range (constant) for compounds
+        gravityRangeCompound: 1.5,
+        // Gravity force (constant) for compounds
+        gravityCompound: 1.0,
+        // Gravity range (constant)
+        gravityRange: 3.8,
+        // Initial cooling factor for incremental layout
+        initialEnergyOnIncremental: 0.3,
+      },
       container: 'cy',
       currentNodeID: 'all',
       currentNode: null,
@@ -380,7 +448,7 @@ export default {
       // reset cytoscape elements
       this.cyInstance.elements().remove()
       this.cyInstance.add(this.elements)
-      this.cyInstance.layout(this.layout).run()
+      this.cyInstance.layout(this.fcoseSettings).run()
       const vm = this
       if (vm.filteredIds && vm.filteredIds.length > 0) {
         this.cyInstance.filter((ele, i, eles) => {
@@ -404,6 +472,7 @@ export default {
 
     preConfig(cytoscape) {
       cytoscape.use(cola)
+      cytoscape.use(fcose)
     },
 
     showNeighbours() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3732,6 +3732,13 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cose-base@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cose-base/-/cose-base-1.0.3.tgz#650334b41b869578a543358b80cda7e0abe0a60a"
+  integrity sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==
+  dependencies:
+    layout-base "^1.0.0"
+
 cosmiconfig@^5.0.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
@@ -4033,6 +4040,13 @@ cytoscape-cola@^2.4.0:
   integrity sha512-zY029SIMi08DRSZatC3oQD7e77ufvkXMiLHmex6Tv2U9F1Qn/+CrQQtjry32VQEYcj0jKj6W/YCH2T+samrCHw==
   dependencies:
     webcola "^3.4.0"
+
+cytoscape-fcose@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/cytoscape-fcose/-/cytoscape-fcose-1.2.3.tgz#185ca64482ca003874c95d1f34a3ffb79661bbfd"
+  integrity sha512-khXpYM3SST8nZIjG1nItJUxgBE8ke2uKxx+CpDQa+zna9jnmKVdJtECuKRt57sD3JyJVx5wFp+6Fvs+p3supdg==
+  dependencies:
+    cose-base "^1.0.0"
 
 cytoscape@^3.8.1:
   version "3.16.3"
@@ -7364,6 +7378,11 @@ launch-editor@^2.2.1:
   dependencies:
     chalk "^2.3.0"
     shell-quote "^1.6.1"
+
+layout-base@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/layout-base/-/layout-base-1.0.2.tgz#1291e296883c322a9dd4c5dd82063721b53e26e2"
+  integrity sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==
 
 left-pad@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
#### Proposed Changes

On initial load use the improved force implementation from the extension `fcose` available (here)[https://github.com/iVis-at-Bilkent/cytoscape.js-fcose]. 

This will only be used on any `reset()` method calls, not individual filters. Individual filters will still use the initial `cose` extension. Therefore any initial loads or filters set to `all` will return this layout.

Settings can be adjusted in the data property:
```js
fcoseSettings: {}
```

![image](https://user-images.githubusercontent.com/38511276/100911014-4b6a6480-3494-11eb-86d3-6a255686c85f.png)


