### PR TITLE
Bug fixes improvements

### DIFF
--- a/src/frontend/components/DataARC.vue
+++ b/src/frontend/components/DataARC.vue
@@ -8,6 +8,7 @@
           :filter-count="filterCount"
           :results="results"
           :filters="compiledFilters"
+          :region-label="regionLabel"
           :concept-filters="conceptFilters"
           :keyword-filters="keywordFilters"
           @removed="removeFilter"
@@ -26,6 +27,7 @@
       id="spatial-section"
       v-model="spatialFilter"
       :filters="compiledFilters"
+      @region-label="setLabel"
       @load-video="setPath"
       @removed="removeFilter"
     />
@@ -48,6 +50,7 @@
       :filters="filters"
       :filter-count="filterCount"
       :concept-filters="conceptFilters"
+      :region-label="regionLabel"
       @removed="removeFilter"
       @filters-loaded="loadFilters"
       @login="$emit('login')"
@@ -148,6 +151,7 @@ export default {
       sampleConcept: '',
       sampleRange: null,
       path: null,
+      regionLabel: '',
     }
   },
   computed: {
@@ -235,6 +239,9 @@ export default {
     }
   },
   methods: {
+    setLabel(label) {
+      this.regionLabel = label
+    },
     loadSavedSearch() {
       this.keywordFilters = []
       this.$refs.keyword.removeFilters()

--- a/src/frontend/components/FilterContainer.vue
+++ b/src/frontend/components/FilterContainer.vue
@@ -47,7 +47,8 @@
                 <b-list-group-item
                   class="d-flex justify-content-between align-items-center text-left bg-transparent"
                 >
-                  <small>Polygon {{ shorten(filters.polygon) }} ...</small>
+                  <span v-if="regionLabel">{{regionLabel}}</span>
+                  <span v-else><small>Polygon {{ shorten(filters.polygon) }} ...</small></span>
                   <b-button variant="dark" @click="$emit('removed', 'polygon')">
                     <b-icon-x-circle-fill
                       variant="light"
@@ -235,6 +236,10 @@ export default {
     },
     filterCount: {
       type: Number,
+      required: true
+    },
+    regionLabel: {
+      type: String,
       required: true
     },
   },

--- a/src/frontend/components/MapContainer.vue
+++ b/src/frontend/components/MapContainer.vue
@@ -149,8 +149,9 @@ export default {
         })
       })
     },
-    addToFilter(payload) {
+    addToFilter(payload, label) {
       this.$emit('input', payload)
+      this.$emit('region-label', label)
     },
     emitRemove() {
       this.$emit('removed', 'polygon')

--- a/src/frontend/components/map-components/Plotly.vue
+++ b/src/frontend/components/map-components/Plotly.vue
@@ -52,6 +52,7 @@ export default {
       ids: [],
       colors: [],
       text: [],
+      selectionLabel: '',
     }
   },
   watch: {
@@ -302,7 +303,8 @@ export default {
                     this.outline.lon.push(firstPoint[0])
                     this.outline.lat.push(firstPoint[1])
                     this.setFilterOutline()
-                    this.$emit('filtered', this.selection)
+                    this.selectionLabel = this.iceland.features[i].properties.name
+                    this.$emit('filtered', this.selection, this.selectionLabel)
                     a = coords.length
                     i = this.iceland.features.length
                   }
@@ -319,7 +321,8 @@ export default {
                 this.outline.lon.push(firstPoint[0])
                 this.outline.lat.push(firstPoint[1])
                 this.setFilterOutline()
-                this.$emit('filtered', this.selection)
+                this.selectionLabel = this.iceland.features[i].properties.name
+                this.$emit('filtered', this.selection, this.selectionLabel)
                 i = this.iceland.features.length
               }
             }

--- a/src/frontend/components/result-components/SearchDialog.vue
+++ b/src/frontend/components/result-components/SearchDialog.vue
@@ -47,11 +47,11 @@
                 <b-card-text class="small">
                   <b-list-group data-type="spatial" v-if="filters.polygon" flush>
                     <b-list-group-item
-                      class="d-flex justify-content-between align-items-center text-left bg-secondary"
+                      class="justify-content-between align-items-center text-left bg-secondary"
                       border-variant="light"
                       style="padding:0.5rem;padding-right:0rem;"
                     >
-                      <small>Polygon</small>
+                      <small>{{ regionLabel ? regionLabel : 'Polygon'}}</small>
                       <b-button size="sm" style="padding:0.1rem;" @click="$emit('removed', 'polygon')">
                         <b-icon-x-circle-fill
                           variant="light"
@@ -203,6 +203,10 @@ export default {
     keywordFilters: {
       type: [Array, Boolean],
       required: true,
+    },
+    regionLabel: {
+      type: String,
+      required: true
     },
   },
   data() {


### PR DESCRIPTION
- fix concepts not filtering when loaded from profile, add concept title to filters sections
- Show Region label in filters 
**Note:** when loading a saved search from the profile page, and it contains a region, it will only label as a polygon in the filters containers, and not attempt to retrieve that label. Can be added later if needed.