### PR TITLE
Fix issues raised in 06 Jan meeting

### DIFF
--- a/src/frontend/components/why-components/DartCitations.vue
+++ b/src/frontend/components/why-components/DartCitations.vue
@@ -1,5 +1,5 @@
 <template>
-    <b-list-group id="citationList" class="overflow-auto" style="height: 200px;">
+    <b-list-group id="citationList" class="overflow-auto" style="height: 300px;">
         <b-list-group-item v-for="(c, index) in citations" :key="index"> 
             <b-icon-card-text class="mr-2"/>
             <span v-html="enhance(c)"/>

--- a/src/frontend/components/why-components/DartCombinatorDetails.vue
+++ b/src/frontend/components/why-components/DartCombinatorDetails.vue
@@ -1,24 +1,26 @@
 <template>
-	<b-card no-body class="m-1">
+	<b-card no-body>
 		<template #header>
 			<b-icon-command class="mr-2"/>
 			<span>Combinator details</span>			
 		</template>	
 		<b-overlay :show="busy" rounded="sm">	
-        <b-card-body class="p-2">
-			<div class="font-weight-bold">{{ combinator.title }}</div>
-			<b-card-text class="overflow-auto" style="height: 75px;">{{ combinator.description }}</b-card-text>
-			<b-tabs content-class="mt-2">
+        	<b-card-text class="overflow-auto p-1" style="height: 100px;">
+				<div class="font-weight-bold">{{ combinator.title }}</div>
+				<div>{{ combinator.description }}</div>
+			</b-card-text>
+			<b-tabs fill content-class="mx-2 my-0 p-0 border-0">
 				<b-tab active>
 					<template v-slot:title>
 						<b-icon-tags />
 						<span class="mx-2">Concepts</span>
-						<b-badge variant="info" pill>{{ $refs.dartCombinatorConcepts.concepts.length }}</b-badge> 																	
+						<b-badge variant="dark">{{ $refs.dartCombinatorConcepts.concepts.length }}</b-badge> 																	
 					</template>
 					<DartConceptList
 						ref="dartCombinatorConcepts" 
 						:concepts="uniqueConcepts" 
 						:showExpanded="false"
+						display="inline"
 						:hilitedConceptIDs="hilitedConceptIDs"
 						@conceptMouseover="conceptMouseover" 
 						@conceptMouseout="conceptMouseout" 
@@ -28,14 +30,13 @@
 					<template v-slot:title>
 						<b-icon-card-text />
 						<span class="mx-2">Citations</span>
-						<b-badge variant="info" pill>{{ $refs.dartCitations.citations.length }}</b-badge> 						    
+						<b-badge variant="dark">{{ $refs.dartCitations.citations.length }}</b-badge> 						    
 					</template>
 					<DartCitations 
 						ref="dartCitations" 
 						:citation="combinator.citation"></DartCitations>
 				</b-tab>    
-			</b-tabs>		
-		</b-card-body>
+			</b-tabs>			
 		</b-overlay>		
     </b-card>
 </template>
@@ -105,7 +106,7 @@ export default {
 			try {
 				self.busy = true			
 				self.combinator = {}
-				let uri = `${self.baseURI}/combinators/${self.clean(encodeURIComponent(id))}`
+				let uri = `${self.$apiUrl}/combinators/${self.clean(encodeURIComponent(id))}`
 				self.getJSON(uri, data => {
 					self.combinator = data
 					self.busy = false
@@ -133,4 +134,3 @@ export default {
 <style scoped>
 
 </style>
-<!--note see https://github.com/vuejs/awesome-vue for lots of VUE examples and resources-->

--- a/src/frontend/components/why-components/DartConcept.vue
+++ b/src/frontend/components/why-components/DartConcept.vue
@@ -2,8 +2,8 @@
     <span>
         <b-badge
             pill 
-            class="border mr-1"
-            variant="secondary" 
+            class="border mt-1 mr-1 px-1 text-dark border-dark"  
+            variant="light" 
             :class="{ hilited: hilited }" 
             role="button" 
             @mouseover="mouseover"
@@ -14,8 +14,7 @@
             <b-icon-tag class="mr-1"/>
             <slot>{{ cleanLabel }}</slot>
         </b-badge>
-        <span class="font-italic text-secondary ml-2" 
-            v-if="showGroup">{{ cleanGroup }}</span>       
+        <span class="font-italic text-secondary ml-2" v-if="showGroup">{{ cleanGroup }}</span>       
     </span>
 </template>
 
@@ -68,6 +67,7 @@ export default {
     },
     methods: {
         mouseover() {
+            this.lilited
             this.$emit('mouseover', { conceptID: this.cleanId })
         },
         mouseout() {

--- a/src/frontend/components/why-components/DartConceptDetails.vue
+++ b/src/frontend/components/why-components/DartConceptDetails.vue
@@ -1,30 +1,32 @@
 <template>
-	<b-card no-body class="m-1">
+	<b-card no-body>
 		<template #header>
 			<b-icon-tag class="mr-2"/>
 			<span>Concept details</span>			
 		</template>
 		<b-overlay :show="busy" rounded="sm">		
-		<b-card-body class="p-2">
-			<div>
-				<span class="font-weight-bold">{{ currentConcept.title }}</span>
-				<span class="font-italic text-secondary ml-2">{{ getGroupLabel(currentConcept.group) }}</span>
-			</div>
-			<b-card-text class="overflow-auto" style="height: 75px;">For further details see <a target="_blank" rel="noopener noreferrer" :href="currentConceptURI">{{currentConcept.title}}</a></b-card-text>	
-			<b-tabs content-class="mt-2">
+			<b-card-text class="overflow-auto p-1" style="height: 100px;">
+				<div>
+					<span class="font-weight-bold">{{ currentConcept.title }}</span>
+					<span class="font-italic text-secondary ml-2">{{ getGroupLabel(currentConcept.group) }}</span>		
+				</div>	
+				<div v-show="currentConceptURI.length > 0">For further details see <a target="_blank" rel="noopener noreferrer" :href="currentConceptURI">{{currentConcept.title}}</a></div>
+			</b-card-text>
+			<b-tabs fill content-class="mx-2 my-0 p-0 border-0">
 				<b-tab active>
 					<!--tab header-->
 					<template v-slot:title>
 						<b-icon-tags />
-						<span class="mx-2">Concepts</span>						
+						<span class="mx-2">Concepts</span>
+						<b-badge variant="dark">{{ conceptCount }}</b-badge> 						
 					</template>
 					<div style="height: 300px;" class="overflow-auto">						
 						<DartExpandedConcept 
-						:concept="currentConcept" 
-                        :hilitedConceptIDs="hilitedConceptIDs"
-                        @conceptMouseover="conceptMouseover" 
-                        @conceptMouseout="conceptMouseout" 
-                        @conceptSelected="conceptSelected"/>					
+							:concept="currentConcept" 
+                        	:hilitedConceptIDs="hilitedConceptIDs"
+                        	@conceptMouseover="conceptMouseover" 
+                        	@conceptMouseout="conceptMouseout" 
+                        	@conceptSelected="conceptSelected"/>					
 					</div>
 				</b-tab>	
 
@@ -33,14 +35,13 @@
 					<template v-slot:title>
 						<b-icon-card-text />
 						<span class="mx-2">Citations</span>
-						<b-badge variant="info" pill>{{ $refs.dartCitations.citations.length }}</b-badge>      
+						<b-badge variant="dark">{{ $refs.dartCitations.citations.length }}</b-badge>      
 					</template>
 					<DartCitations ref="dartCitations" :citation="currentConcept.citation"></DartCitations>
 				</b-tab>
 
-			</b-tabs>
+			</b-tabs>	
 		
-		</b-card-body>
 		</b-overlay>
 	</b-card>
 </template>
@@ -80,9 +81,26 @@ export default {
 	},
 	computed: {
 		currentConceptURI(){
-			let conceptName = encodeURIComponent(this.clean(this.currentConcept.name))
-			return `https://ropitz.github.io/experiments/dataarc-concepts/${conceptName}.html`
+			return (this.currentConcept || {}).url || ""
+			//let conceptName = encodeURIComponent(this.clean(this.currentConcept.name))
+			//return `https://ropitz.github.io/experiments/dataarc-concepts/${conceptName}.html`
+		},
+		conceptCount() {
+			if(this.currentConcept) {
+				let uniqueRelated = new Set()
+            	for (let c of this.currentConcept.related || []) {
+                	uniqueRelated.add(c.id)
+				}
+				let uniqueContextual = new Set()
+            	for (let c of this.currentConcept.contextual || []) {
+                	uniqueContextual.add(c.id)
+				}
+				return 1 + uniqueRelated.size + uniqueContextual.size
+            } 
+			else
+				return 0
 		}
+
 	},
 	watch: {
         conceptID: {
@@ -102,7 +120,7 @@ export default {
 				self.busy = true
 				self.currentConcept = {}			
 				let cleanID = encodeURIComponent(self.clean(conceptID))
-				let uri = `${self.baseURI}/concepts/${cleanID}`		
+				let uri = `${self.$apiUrl}/concepts/${cleanID}`		
 				self.getJSON(uri, data => {					
 					self.currentConcept = data
 					self.busy = false
@@ -150,4 +168,5 @@ li {
     background:palegreen;
 	color: darkgreen;
 }
+
 </style>

--- a/src/frontend/components/why-components/DartConceptList.vue
+++ b/src/frontend/components/why-components/DartConceptList.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <b-form-radio-group size="sm" buttons v-model="listDisplay">           
+        <b-form-radio-group buttons v-model="listDisplay">           
             <b-form-radio name="listDisplay" value="listed">listed</b-form-radio>
             <b-form-radio name="listDisplay" value="grouped">grouped</b-form-radio>
             <b-form-radio name="listDisplay" value="inline">inline</b-form-radio>
@@ -31,7 +31,7 @@
                     <details>
                         <summary>
                             <span class="font-italic text-secondary">{{ group.replace("_", " ") }}</span> 
-                            <b-badge class="font-italic m-1" variant="secondary" pill>{{ conceptsInGroup(group).length }}</b-badge><br> 
+                            <b-badge class="font-italic m-1" variant="dark">{{ conceptsInGroup(group).length }}</b-badge><br> 
                         </summary> 
                         <DartConcept v-for="(concept, cindex) in conceptsInGroup(group)"
                             :key="cindex"
@@ -85,11 +85,17 @@ export default {
             type: Boolean,
             required: false,
             default: true
+        },
+        display: {
+            type: String,
+            required: false,
+            default: "listed",
+            validator: value => ["listed", "grouped", "inline"].includes(value)      
         }			
 	},
 	data: function() {
 		return {
-            listDisplay: "listed" // "listed" | "grouped" | "inline" 
+            listDisplay: this.display // "listed" | "grouped" | "inline" 
         }
     },
     watch: {},

--- a/src/frontend/components/why-components/DartExpandedConcept.vue
+++ b/src/frontend/components/why-components/DartExpandedConcept.vue
@@ -1,7 +1,7 @@
 <template>
     <details>
         <summary>
-            <DartConcept 
+            <DartConcept
                 :id="currentConcept.id"
                 :label="currentConcept.title"
                 :group="currentConcept.group"
@@ -14,7 +14,7 @@
         <details class="ml-2">
             <summary>
                 <span class="font-italic text-secondary mx-1">Related</span> 
-				<b-badge class="font-italic m-1" variant="secondary" pill>{{ related.length }}</b-badge>
+				<b-badge class="font-italic m-1" variant="dark">{{ related.length }}</b-badge>
             </summary>
              <b-list-group class="ml-2">
                 <li v-for="(c, index) in related" :key="index">
@@ -33,7 +33,7 @@
         <details class="ml-2">
             <summary>
                 <span class="font-italic text-secondary mx-1">Contextual</span> 
-				<b-badge class="font-italic m-1" variant="secondary" pill>{{ contextual.length }}</b-badge>
+				<b-badge class="font-italic m-1" variant="dark">{{ contextual.length }}</b-badge>
             </summary>
             <b-list-group class="ml-3">
                 <li v-for="(c, index) in contextual" :key="index">

--- a/src/frontend/components/why-components/DartQueryConcepts.vue
+++ b/src/frontend/components/why-components/DartQueryConcepts.vue
@@ -1,33 +1,38 @@
 <template>
-    <b-card no-body class="m-1">
+    <b-card no-body>
         <template #header>
             <b-icon-tags />
             <span class="mx-2">Concepts for query</span>
         </template>
-        <b-overlay :show="busy">	
-            <b-form-radio-group size="sm" buttons v-model="display">           
-				<b-form-radio name="display" value="matched">
-                    <b-badge class="matched">matched {{ uniqueMatchedConcepts.length }}</b-badge>
-                </b-form-radio>
-				<b-form-radio name="display" value="related">
-                    <b-badge class="related">related {{ uniqueRelatedConcepts.length }}</b-badge>
-                </b-form-radio>
-				<b-form-radio name="display" value="contextual">
-                    <b-badge class="contextual">contextual {{ uniqueContextualConcepts.length }}</b-badge>
-                </b-form-radio>
-				<b-form-radio name="display" value="all">
-                    <b-badge variant="dark">all {{ uniqueAllConcepts.length }}</b-badge>
-                </b-form-radio>
-			</b-form-radio-group>
-			<DartConceptList
-                class="p-1"
-                ref="dartConceptList" 
-                :concepts="displayedConcepts" 
-                :showExpanded="false"
-                :hilitedConceptIDs="hilitedConceptIDs"
-                @conceptMouseover="conceptMouseover" 
-                @conceptMouseout="conceptMouseout" 
-                @conceptSelected="conceptSelected"/> 
+        <b-overlay :show="busy">
+            <div class="bg-secondary text-center">	
+                <b-form-radio-group size="sm" buttons v-model="display" class="border-0">           
+                    <b-form-radio name="display" value="matched">
+                        <b-badge variant="dark">matched {{ uniqueMatchedConcepts.length }}</b-badge>
+                    </b-form-radio>
+                    <b-form-radio name="display" value="related">
+                        <b-badge variant="dark">related {{ uniqueRelatedConcepts.length }}</b-badge>
+                    </b-form-radio>
+                    <b-form-radio name="display" value="contextual">
+                        <b-badge variant="dark">contextual {{ uniqueContextualConcepts.length }}</b-badge>
+                    </b-form-radio>
+                    <b-form-radio name="display" value="all">
+                        <b-badge variant="dark">all {{ uniqueAllConcepts.length }}</b-badge>
+                    </b-form-radio>
+                </b-form-radio-group>
+            </div>
+            <b-card-text>
+                <DartConceptList
+                    class="p-1"
+                    ref="dartConceptList" 
+                    :concepts="displayedConcepts" 
+                    display="inline"
+                    :showExpanded="false"
+                    :hilitedConceptIDs="hilitedConceptIDs"
+                    @conceptMouseover="conceptMouseover" 
+                    @conceptMouseout="conceptMouseout" 
+                    @conceptSelected="conceptSelected"/>
+            </b-card-text> 
         </b-overlay>	      
     </b-card>
 </template>
@@ -137,7 +142,9 @@ export default {
 
 		getConcepts(conceptIDs) {
             // get (selected) properties of the query concepts 
-            let self = this            
+            let self = this 
+            self.concepts = []
+            if(conceptIDs.length == 0) return          
             
              try {
                 self.busy = true
@@ -200,5 +207,5 @@ li {
 }
 .matched { background: #28A745; }
 .related { background: #FFC101; }
-.contextual { background: #DC3545; }
+.contextual { background: blue; }
 </style>

--- a/src/frontend/components/why-components/DartQueryExplainer.vue
+++ b/src/frontend/components/why-components/DartQueryExplainer.vue
@@ -1,7 +1,11 @@
 <template>
-    <div class="shadow border p-3" >
-        <b-card-group deck>
-            <DartQueryConcepts 
+    <!--<div class="shadow border p-3" >-->
+    <b-container>
+    <b-row>
+    <b-col>
+        <div class="p-3 shadow">
+        <b-card-group deck class="my-3">
+            <DartQueryConcepts
                 :conceptIDs="filter.concept" 
                 :hilitedConceptIDs="hilitedConceptIDs"
                 @conceptMouseover="conceptMouseover" 
@@ -14,10 +18,11 @@
                 @combinatorMouseout="combinatorMouseout"
                 @combinatorSelected="combinatorSelected"/>     
             <DartQueryResults 
+                :conceptIDs="filter.concept"
                 :filter="filter"
                 @datasetSelected="datasetSelected"/>               
         </b-card-group> 
-        <b-card-group deck>   
+        <b-card-group deck class="my-5">   
             <DartConceptDetails 
                 :conceptID="selectedConceptID" 
                 :hilitedConceptIDs="hilitedConceptIDs"
@@ -37,7 +42,11 @@
                 @combinatorMouseout="combinatorMouseout"
                 @combinatorSelected="combinatorSelected"/> 
         </b-card-group>
-    </div>
+        </div>
+    </b-col>
+    </b-row>
+    
+    </b-container>
 </template>
 
 <script>
@@ -62,8 +71,7 @@ export default {
 	props: {
         filter: {
             type: Object,
-            required: false,
-            default: () => {}
+            required: true
         }        	
 	},
 	data() {
@@ -97,8 +105,8 @@ export default {
         combinatorSelected(com) {
             this.selectedCombinatorID = com.id
         },
-        datasetSelected(d) {
-            this.selectedDatasetID = d.dataset_id
+        datasetSelected(id) {
+            this.selectedDatasetID = id
         },
     },
 	// lifecycle hooks

--- a/src/frontend/components/why-components/DartQueryResults.vue
+++ b/src/frontend/components/why-components/DartQueryResults.vue
@@ -1,37 +1,43 @@
 
 <template>
-	<b-card no-body class="m-1">
+	<b-card no-body>
         <template #header>
             <b-icon-card-list />
-            <span class="mx-2">Dataset results for query</span>  			                 
+            <span class="mx-2">Datasets for query</span>  			                 
         </template> 
 		<b-overlay :show="busy" rounded="sm">
-			<b-form-radio-group size="sm" buttons v-model="display"> 
-				<b-form-radio name="display" value="archaeological">
-                    <b-badge class="archaeological">archaeo {{ resultTotals.archaeological }}</b-badge>
-                </b-form-radio>          
-				<b-form-radio name="display" value="environmental" >
-                    <b-badge class="environmental">enviro {{ resultTotals.environmental }}</b-badge>
-                </b-form-radio>
-				
-				<b-form-radio name="display" value="textual">
-                    <b-badge class="textual">textual {{ resultTotals.textual }}</b-badge>
-                </b-form-radio>
-				<b-form-radio name="display" value="all">
-                    <b-badge variant="dark">all {{ resultTotals.all }}</b-badge>
-                </b-form-radio>
-			</b-form-radio-group>
-
-			<div id="resultList" class="overflow-auto m-0" style="height: 300px;">				     
-				<div v-for="(result, rindex) in resultsToDisplay" :key="rindex">					
-					<b-list-group-item button v-for="(dataset, dindex) in result.datasets" 
-						:key="dindex" 
-						@click.prevent="datasetSelected(dataset)">
-						<b-icon-card-list class="mr-2"/>
-						<span>{{ dataset.dataset }}</span>
-						<b-badge class="ml-2" variant="secondary" pill>{{ dataset.total }}</b-badge>						
+			<div class="bg-secondary text-center">
+				<b-form-radio-group size="sm" buttons v-model="display" class="border-0">           
+					<b-form-radio name="display" value="matched">
+						<b-badge variant="dark">matched {{ matchedDatasets.length }}</b-badge>
+					</b-form-radio>
+					<b-form-radio name="display" value="related">
+						<b-badge variant="dark">related {{ relatedDatasets.length }}</b-badge>
+					</b-form-radio>
+					<b-form-radio name="display" value="contextual">
+						<b-badge variant="dark">contextual {{ contextualDatasets.length }}</b-badge>
+					</b-form-radio>
+					<b-form-radio name="display" value="all">
+						<b-badge variant="dark">all {{ allDatasets.length }}</b-badge>
+					</b-form-radio>
+				</b-form-radio-group>
+			</div>
+			<div id="datasetList" class="overflow-auto m-0" style="height: 300px;">				     
+				<!--<div v-for="(result, rindex) in resultsToDisplay" :key="rindex"> 
+					<b-list-group-item button v-for="(dataset, dindex) in result.datasets" -->
+					<b-list-group-item button v-for="(dataset, index) in datasetsToDisplay"	
+						:key="index" 
+						:alt="dataset.title"
+						:title="dataset.title"
+						:class="`text-${dataset.category}`"
+						@click.prevent="datasetSelected(dataset.id)">
+						<b-card-text>
+							<b-icon-card-list class="mr-2"/>
+							<span>{{ dataset.title }}</span>
+							<!--<b-badge class="ml-2" variant="dark">{{ dataset.total }}</b-badge>-->
+						</b-card-text>						
 					</b-list-group-item>
-				</div>
+				<!--</div>-->
 			</div>     
 		</b-overlay>
 	</b-card>
@@ -45,68 +51,126 @@ export default {
 	components: { 
 	},
 	mixins: [ DartCommon ],
-	props: {
+	props: {		
 		filter: {
             type: Object,
-            required: false,
-			default: () => {} 
-		}
+            required: true			
+		},
+		conceptIDs: {
+			type: Array, // note: only passed because filter watch didn't react to concept array changes
+			required: false,
+			default: () => []            
+		},	
 	},
+
 	data() {
 		return {
 			busy: false,
-			display: "textual",
-			queryFilter: this.filter,
-			results: []			
+			display: "all",
+			matchedDatasets: [],
+			relatedDatasets: [],
+			contextualDatasets: []		
 		}
 	},
-	computed: { 
-		resultTotals() {
-			let totals = {
-				environmental: 0, 
-				archaeological: 0, 
-				textual: 0, 
-				other: 0,
-				all: 0
-			}	
-			this.results.forEach(r => {
-				switch(r.category.toLowerCase()) {
-					case "environmental": totals.environmental = r.total; break;
-					case "archaeological": totals.archaeological = r.total; break;
-					case "textual": totals.textual = r.total; break;
-					default: totals.other += r.total; break;
+
+	computed: {
+		allDatasets() {			
+			// get all datasets concatenated
+			let datasets = this.matchedDatasets
+				.concat(this.relatedDatasets)
+				.concat(this.contextualDatasets)
+
+			// ensure uniqueness
+			const uniqueDatasets = new Map()
+			datasets.forEach(ds => {
+				if (!uniqueDatasets.has(ds.id)) {
+					uniqueDatasets.set(ds.id, ds)
 				}
-				totals.all += r.total				
 			})
-			return totals
-			// return a.reduce(function (total, obj) { return total + obj.total }, 0);
-			
-		},
-		resultsToDisplay() {
-			if(this.display != "all")
-				return this.results.filter(r => r.category.toLowerCase() == this.display)
-			else
-				return this.results
+
+			// return sorted by title
+			return[...uniqueDatasets.values()].sort((a,b) => a.title.localeCompare(b.title))
+		},	
+		
+		// TODO: need flat list of datasets, sorted by label/title....
+		datasetsToDisplay() {
+			let datasets = []
+
+			switch(this.display) {
+				case "matched": datasets = this.matchedDatasets; break;
+				case "related": datasets = this.relatedDatasets; break;
+				case "contextual": datasets = this.contextualDatasets; break;
+				default: datasets = this.allDatasets; break;
+			}			
+			return datasets
+
 		}		
 	},
-	watch: {
+	watch: {		
         filter: {
             immediate: true,
             handler(newValue) {
-				if(newValue.concept)             
-					this.getResults()
+				this.getAllDatasets()
             }        
-		}		
+		},
+		conceptIDs: {
+            immediate: true,
+            handler(newValue) { 
+				this.getAllDatasets()				
+			}
+		}
+	
 	},
 	methods: {
-		getResults() {
+		
+		getAllDatasets() {
+			this.getDatasets(Object.assign({}, this.filter || {}, { type: "matched" }))
+			this.getDatasets(Object.assign({}, this.filter || {}, { type: "related" }))
+			this.getDatasets(Object.assign({}, this.filter || {}, { type: "contextual" }))
+		},
+		
+		getDatasets(filter) {
 			let self = this
+
+			// clear previous results
+			self.matchedDatasets = []
+			self.relatedDatasets = []
+			self.contextualDatasets = []
+			
+			// if no query concepts then return empty array
+			if((filter.concept || []).length == 0) return []
 
 			try {
 				self.busy = true
-				let uri = `${self.baseURI}/query/results`    
-				self.postJSON(uri, self.queryFilter, json => {
-					self.results = json || []
+				let uri = `${self.$apiUrl}/query/results`    
+				self.postJSON(uri, filter, json => {
+					let results = (json || [])
+
+					// get list of unique datasets from results
+					const uniqueDatasets = new Map()
+					results.forEach(result => {
+						result.datasets.forEach(dataset => {
+							if (!uniqueDatasets.has(dataset.id)) {
+								const ds = { 
+									id: dataset.dataset_id, 
+									category: result.category.toLowerCase(),
+									title: dataset.dataset
+								}
+          						uniqueDatasets.set(ds.id, ds)
+							}
+						})
+					})
+
+					// sort by title	
+					let sortedDatasets = [...uniqueDatasets.values()]
+						.sort((a,b) => a.title.localeCompare(b.title))
+					
+					// put in correct place
+					switch(filter.type) {
+						case "related": self.relatedDatasets = sortedDatasets; break;
+						case "contextual": self.contextualDatasets = sortedDatasets; break;
+						default: self.matchedDatasets = sortedDatasets; break;
+					}
 					self.busy = false
 				})
 			}
@@ -139,4 +203,8 @@ li {
 .archaeological { background: #6177AA; }
 .textual { background: #FC8D62; }
 .environmental { background: #66C2A5; }
+
+.matched { background: #28A745; }
+.related { background: #FFC101; }
+.contextual { background: blue; }
 </style>

--- a/src/frontend/components/why-components/DartQueryResultsOld.vue
+++ b/src/frontend/components/why-components/DartQueryResultsOld.vue
@@ -1,0 +1,157 @@
+
+<template>
+	<b-card no-body>
+        <template #header>
+            <b-icon-card-list />
+            <span class="mx-2">Datasets for query</span>  			                 
+        </template> 
+		<b-overlay :show="busy" rounded="sm">
+			<div class="bg-secondary text-center">	
+				<b-form-radio-group size="sm" buttons v-model="display" class="bg-secondary border-0"> 
+					<b-form-radio name="display" value="archaeological">
+						<b-badge class="archaeological">archaeo {{ resultTotals.archaeological }}</b-badge>
+					</b-form-radio>          
+					<b-form-radio name="display" value="environmental" >
+						<b-badge class="environmental">enviro {{ resultTotals.environmental }}</b-badge>
+					</b-form-radio>
+					
+					<b-form-radio name="display" value="textual">
+						<b-badge class="textual">textual {{ resultTotals.textual }}</b-badge>
+					</b-form-radio>
+					<b-form-radio name="display" value="all">
+						<b-badge variant="dark">all {{ resultTotals.all }}</b-badge>
+					</b-form-radio>
+				</b-form-radio-group>
+			</div>
+			<div id="resultList" class="overflow-auto m-0" style="height: 300px;">				     
+				<div v-for="(result, rindex) in resultsToDisplay" :key="rindex">					
+					<b-list-group-item button v-for="(dataset, dindex) in result.datasets" 
+						:key="dindex" 
+						:alt="dataset.dataset"
+						:title="dataset.dataset"
+						@click.prevent="datasetSelected(dataset)">
+						<b-card-text>
+							<b-icon-card-list class="mr-2"/>
+							<span>{{ dataset.dataset }}</span>
+							<b-badge class="ml-2" variant="dark">{{ dataset.total }}</b-badge>
+						</b-card-text>						
+					</b-list-group-item>
+				</div>
+			</div>     
+		</b-overlay>
+	</b-card>
+</template>
+
+<script>
+import DartCommon from '@/mixins/DartCommon.js'
+
+export default {
+	name: 'DartQueryResults',
+	components: { 
+	},
+	mixins: [ DartCommon ],
+	props: {		
+		filter: {
+            type: Object,
+            required: true			
+		},
+		conceptIDs: {
+			type: Array, // note: only passed because filter watch didn't react to concept array changes
+			required: false,
+			default: () => []            
+		},	
+	},
+	data() {
+		return {
+			busy: false,
+			display: "all",
+			results: []			
+		}
+	},
+	computed: { 		
+		resultTotals() {
+			let totals = {
+				environmental: 0, 
+				archaeological: 0, 
+				textual: 0, 
+				other: 0,
+				all: 0
+			}	
+			this.results.forEach(r => {
+				switch(r.category.toLowerCase()) {
+					case "environmental": totals.environmental += r.datasets.length; break;
+					case "archaeological": totals.archaeological += r.datasets.length; break;
+					case "textual": totals.textual += r.datasets.length; break;
+					default: totals.other += r.datasets.length; break;					
+				}
+				totals.all += r.datasets.length			
+			})
+			return totals			
+		},
+		resultsToDisplay() {
+			if(this.display != "all")
+				return this.results.filter(r => r.category.toLowerCase() == this.display)
+			else
+				return this.results
+		}		
+	},
+	watch: {		
+        filter: {
+            immediate: true,
+            handler(newValue) {
+				this.getResults()
+            }        
+		},
+		conceptIDs: {
+            immediate: true,
+            handler(newValue) { 
+				this.getResults()
+			}
+		}
+	
+	},
+	methods: {
+		getResults() {
+			let self = this
+			self.results = []
+			
+			if(((self.filter || {}).concept || []).length == 0) return
+
+			try {
+				self.busy = true
+				let uri = `${self.$apiUrl}/query/results`    
+				self.postJSON(uri, self.filter, json => {
+					self.results = json || []
+					self.busy = false
+				})
+			}
+			catch(err){ 
+				console.log(err) 
+				self.busy = false
+			}			
+		},		
+		datasetSelected(dataset) {
+			this.$emit('datasetSelected', dataset) 
+		}
+	},
+	// lifecycle hooks
+	beforeCreate() {},
+	created() {},
+	beforeMount() {},
+	mounted() {},
+	beforeUpdate() {},
+	updated() {},
+	beforeDestroy() {},
+	destroyed() {}
+}
+</script>
+
+<style scoped>
+li {
+    display: block;
+}
+/* Note -after integration get colors from central CSS? */
+.archaeological { background: #6177AA; }
+.textual { background: #FC8D62; }
+.environmental { background: #66C2A5; }
+</style>

--- a/src/frontend/components/why-components/DartResultDetails.vue
+++ b/src/frontend/components/why-components/DartResultDetails.vue
@@ -1,39 +1,56 @@
 <template>
-	<b-card no-body class="m-1">
+	<b-card no-body>
         <template #header>
-            <b-icon-card-list class="mr-1"/>
+            <b-icon-card-list class="mr-2"/>
             <span>Dataset details</span>                   
         </template>
 		<b-overlay :show="busy" rounded="sm">	
-		<b-card-body class="p-2">
-        <div class="font-weight-bold" >{{ dataset.title }}</div>
-		<b-card-text class="overflow-auto" style="height: 75px;">{{ dataset.description }}</b-card-text>
-		<!--<ul class="p-1" v-for="(c, index) in dataset.combinators" :key="index">
-			<li>{{ c.title }}</li>	
-		</ul>-->
-		<b-tabs content-class="mt-2">
-			<b-tab active>
-				<template v-slot:title>
-					<b-icon-command />
-					<span class="mx-2">Combinators</span>
-					<b-badge variant="info" pill>{{ combinatorsByTitle.length }}</b-badge>
-				</template>
-				<b-list-group id="combinatorList" class="overflow-auto" style="height: 300px;">
-					<b-list-group-item class="py-1" v-for="com in combinatorsByTitle" 
-						:key="com.id" 
-						:alt="com.title"
-						:title="com.title"
-						:class="{ hilited: com.hilited }"
-						@mouseover="combinatorMouseover(com)"
-						@mouseout="combinatorMouseout(com)"
-						@click.prevent="combinatorSelected(com)">
-						<b-icon-command class="mr-2"/>
-						<span>{{ com.title }}</span>
-					</b-list-group-item>
-				</b-list-group>
-			</b-tab>
-		</b-tabs>
-		</b-card-body>
+			<b-card-text class="overflow-auto p-1" style="height: 100px;">
+				<div class="font-weight-bold">{{ (dataset || {}).title || "" }}</div>
+				<div>{{ (dataset || {}).description || "" }}</div>
+			</b-card-text>
+
+
+			<b-tabs content-class="mx-2 my-0 p-0 border-0">
+				<b-tab active>
+					<template v-slot:title>
+						<b-icon-command />
+						<span class="mx-2">Combinators</span>
+						<b-badge variant="dark">{{ combinatorsByTitle.length }}</b-badge>																	
+					</template>
+				
+			<!--<ul class="p-1" v-for="(c, index) in dataset.combinators" :key="index">
+				<li>{{ c.title }}</li>	
+			</ul>-->
+			<!--<b-card-text class="p-1">
+				<b-icon-command />
+				<span class="mx-2">Combinators</span>
+				<b-badge variant="dark">{{ combinatorsByTitle.length }}</b-badge>
+			</b-card-text>-->
+			<!--<b-tabs content-class="mt-2 p-0">
+				<b-tab active>
+					<template v-slot:title>
+						<b-icon-command />
+						<span class="mx-2">Combinators</span>
+						<b-badge variant="info" pill>{{ combinatorsByTitle.length }}</b-badge>
+					</template>-->
+					<b-list-group id="combinatorList" class="overflow-auto" style="height: 300px;">
+						<b-list-group-item class="py-1" v-for="com in combinatorsByTitle" 
+							:key="com.id" 
+							:alt="com.title || ''"
+							:title="com.title || ''"
+							:class="{ hilited: com.hilited }"
+							@mouseover="combinatorMouseover(com)"
+							@mouseout="combinatorMouseout(com)"
+							@click.prevent="combinatorSelected(com)">
+							<b-card-text>
+								<b-icon-command class="mr-2"/>
+								<span>{{ com.title }}</span>
+							</b-card-text>
+						</b-list-group-item>
+					</b-list-group>
+				</b-tab>
+			</b-tabs>			
 		</b-overlay>	
 	</b-card>
 </template>
@@ -64,14 +81,14 @@ export default {
 			dataset: {}
 		}
 	},
-	computed: {
+	computed: { 
 		combinatorsByTitle: function() {
 			return ((this.dataset || {}).combinators || []).slice()
-				.map(com => { // convert from array of ID to array of obj
-					com.concepts = (com.concepts || []).map(id => { return {id: id}})
-					return com
-				})
-                .sort((a, b) => a.title.localeCompare(b.title))
+				//.map(com => { // convert from array of ID to array of obj
+					//com.concepts = (com.concepts || []).map(id => { return {id: id}})
+					//return com
+				//})
+                .sort((a, b) => (a.title || "").localeCompare(b.title || ""))
         }	
 	},
 	watch: {
@@ -79,7 +96,7 @@ export default {
             immediate: true,
             handler(newValue) {
 				if(newValue !== "")                
-					this.getDataset2(newValue)            
+					this.getDataset(newValue)            
             }        
 		},
 
@@ -91,29 +108,10 @@ export default {
             })
 		}
 	},
-	methods: {
-        /*getDataset(id){
+	methods: {    		
+		getDataset(id){
 			let self = this
 			
-			try {
-				self.busy = true			
-				let uri = `${self.baseURI}/datasets/${self.clean(encodeURIComponent(id))}`
-				self.getJSON(uri, data => {
-					self.dataset = data
-					self.busy = false
-				})
-			}
-			catch(err) { 
-				console.log(err) 
-				self.busy = false
-			}			
-		},*/
-
-		// API call above returned extra data - retrieving 
-		// what we need, seems faster in informal testing 
-		getDataset2(id){
-			let self = this
-			console.log(id)
 			try {
 				self.busy = true
 				let cleanID = self.clean(encodeURIComponent(id))			

--- a/src/mixins/DartCommon.js
+++ b/src/mixins/DartCommon.js
@@ -1,7 +1,7 @@
 const DartCommon = { 
   data() {
 		return {
-      baseURI: "https://api.data-arc.org"
+      //baseURI: "https://api.data-arc.org"
     }
 	},  
   methods: {
@@ -68,7 +68,7 @@ const DartCommon = {
           
     // run GraphQL query 
     runQuery(query, callback, error) {
-      let uri = `${this.baseURI}/graphql?query=${encodeURIComponent(query)}`
+      let uri = `${this.$apiUrl}/graphql?query=${encodeURIComponent(query)}`
       this.getJSON(uri, callback, error)
     }
   }


### PR DESCRIPTION
Make 'all' the default results tab
Make 'inline' the default concept display
Change URI for concept scope notes
Don't show results until concept filtered
Remove spurious '1' from combinators list
Replace any local hardcoded base URI
Results control revisions and colour coding
General formatting and sizing improvements